### PR TITLE
Match required PHP version from readme to be 8.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"wp-cli/wp-cli-bundle": "^2.12"
 	},
 	"require": {
-		"php": ">=8.0"
+		"php": ">=8.1"
 	},
 	"license": "GPL-2.0-or-later",
 	"autoload": {


### PR DESCRIPTION
The readme requirements say PHP 8.1+ is required but the composer.json only has PHP 8.0+

https://github.com/PedalCMS/wp-cmf#requirements