### PR TITLE
Add release workflow and documentation

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,43 @@
+# Distribution Ignore File
+# Files and directories listed here are excluded from release packages.
+# This file is for documentation purposes - the actual exclusion happens in the release workflow.
+
+# Development
+.git/
+.github/
+.cache/
+.editorconfig
+.gitignore
+.gitattributes
+
+# Testing
+tests/
+bin/
+phpunit.xml.dist
+phpunit.xml
+
+# Code Quality
+phpcs.xml.dist
+phpcs.xml
+.phpcs.xml
+phpstan.neon.dist
+phpstan.neon
+.phpstan.neon
+
+# Composer Dev
+composer.lock
+
+# Examples (users can find these in the repository)
+examples/
+
+# Documentation (available in repository)
+docs/
+
+# IDE
+.idea/
+.vscode/
+*.code-workspace
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer
+
+      - name: Get version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ steps.version.outputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version format. Expected: X.Y.Z"
+            exit 1
+          fi
+
+      - name: Install dependencies (production only)
+        run: composer install --prefer-dist --no-dev --no-progress --optimize-autoloader
+
+      - name: Create distribution package
+        run: |
+          mkdir -p dist/wp-cmf
+
+          # Copy only production files
+          cp -r src dist/wp-cmf/
+          cp composer.json dist/wp-cmf/
+          cp README.md dist/wp-cmf/
+          cp LICENSE dist/wp-cmf/
+          cp CHANGELOG.md dist/wp-cmf/ 2>/dev/null || echo "No CHANGELOG.md found"
+
+          # Copy vendor (production only - already installed with --no-dev)
+          cp -r vendor dist/wp-cmf/
+
+          # Remove unnecessary files from dist
+          cd dist/wp-cmf
+
+          # Remove dev/test files that might have been copied
+          rm -rf tests/
+          rm -rf bin/
+          rm -rf docs/
+          rm -rf examples/
+          rm -rf .github/
+          rm -rf .git/
+          rm -rf .cache/
+          rm -f .gitignore
+          rm -f .gitattributes
+          rm -f .editorconfig
+          rm -f phpunit.xml.dist
+          rm -f phpcs.xml.dist
+          rm -f phpstan.neon.dist
+          rm -f composer.lock
+          rm -f .phpcs.xml
+          rm -f .phpstan.neon
+
+          cd ..
+
+          # Create zip archive
+          zip -r ../wp-cmf-${{ steps.version.outputs.version }}.zip wp-cmf
+
+          # Create tarball
+          tar -czf ../wp-cmf-${{ steps.version.outputs.version }}.tar.gz wp-cmf
+
+          cd ..
+
+          # Show what's included
+          echo "Package contents:"
+          unzip -l wp-cmf-${{ steps.version.outputs.version }}.zip | head -50
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          # Extract notes from CHANGELOG.md if it exists
+          if [ -f CHANGELOG.md ]; then
+            # Extract section for current version
+            NOTES=$(awk '/^## \[?${{ steps.version.outputs.version }}\]?/{flag=1; next} /^## \[?[0-9]+\.[0-9]+\.[0-9]+\]?/{flag=0} flag' CHANGELOG.md)
+            if [ -n "$NOTES" ]; then
+              echo "notes<<EOF" >> $GITHUB_OUTPUT
+              echo "$NOTES" >> $GITHUB_OUTPUT
+              echo "EOF" >> $GITHUB_OUTPUT
+            else
+              echo "notes=Release ${{ steps.version.outputs.tag }}" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "notes=Release ${{ steps.version.outputs.tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: WP-CMF ${{ steps.version.outputs.tag }}
+          body: ${{ steps.release_notes.outputs.notes }}
+          draft: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+          files: |
+            wp-cmf-${{ steps.version.outputs.version }}.zip
+            wp-cmf-${{ steps.version.outputs.version }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## Release Created Successfully! :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ steps.version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Assets:**" >> $GITHUB_STEP_SUMMARY
+          echo "- wp-cmf-${{ steps.version.outputs.version }}.zip" >> $GITHUB_STEP_SUMMARY
+          echo "- wp-cmf-${{ steps.version.outputs.version }}.tar.gz" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to WP-CMF will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Nothing yet
+
+### Changed
+- Nothing yet
+
+### Fixed
+- Nothing yet
+
+## [0.1.0] - 2025-01-01
+
+### Added
+- Initial release
+- Custom Post Type registration with fields
+- Custom Taxonomy registration with term meta fields
+- Settings Pages (top-level and submenu)
+- 16 field types: text, textarea, number, email, url, password, date, color, select, checkbox, radio, wysiwyg, tabs, metabox, group, repeater
+- Container fields: tabs, metabox, group, repeater
+- Extend existing post types, taxonomies, and settings pages
+- Array-based configuration
+- JSON file configuration with schema validation
+- Before-save filters for field values
+- Built-in validation and sanitization
+- Context-aware asset management
+- Full internationalization (i18n) support
+- PHPStan static analysis (level 5)
+- WordPress Coding Standards compliance
+- Comprehensive test suite
+
+[Unreleased]: https://github.com/PedalCMS/wp-cmf/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/PedalCMS/wp-cmf/releases/tag/v0.1.0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,153 @@
+# Release Process
+
+This document describes how to create a new release of WP-CMF.
+
+## Prerequisites
+
+- All tests passing (`composer test`)
+- All code standards passing (`composer cs:all`)
+- PHPStan passing (`composer analyse`)
+- Changes documented in `CHANGELOG.md`
+
+## Version Numbering
+
+WP-CMF follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (X.0.0): Breaking changes
+- **MINOR** (0.X.0): New features, backward compatible
+- **PATCH** (0.0.X): Bug fixes, backward compatible
+
+### Pre-release Versions
+
+- Alpha: `v1.0.0-alpha.1`
+- Beta: `v1.0.0-beta.1`
+- Release Candidate: `v1.0.0-rc.1`
+
+## Release Steps
+
+### 1. Update CHANGELOG.md
+
+Move items from `[Unreleased]` to a new version section:
+
+```markdown
+## [Unreleased]
+
+## [1.0.0] - 2025-01-15
+
+### Added
+- New feature X
+- New feature Y
+
+### Changed
+- Updated behavior of Z
+
+### Fixed
+- Bug fix A
+```
+
+Update the comparison links at the bottom:
+
+```markdown
+[Unreleased]: https://github.com/PedalCMS/wp-cmf/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/PedalCMS/wp-cmf/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/PedalCMS/wp-cmf/releases/tag/v0.1.0
+```
+
+### 2. Update Version in README.md
+
+Update the version badge:
+
+```markdown
+[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](https://github.com/PedalCMS/wp-cmf)
+```
+
+### 3. Commit Changes
+
+```bash
+git add CHANGELOG.md README.md
+git commit -m "Prepare release v1.0.0"
+git push origin main
+```
+
+### 4. Create and Push Tag
+
+```bash
+git tag -a v1.0.0 -m "Release v1.0.0"
+git push origin v1.0.0
+```
+
+### 5. Automated Release
+
+The GitHub Actions workflow will automatically:
+
+1. Validate the version format
+2. Install production dependencies
+3. Create distribution packages (`.zip` and `.tar.gz`)
+4. Extract release notes from CHANGELOG.md
+5. Create a GitHub Release with assets
+
+### 6. Verify Release
+
+1. Go to [Releases](https://github.com/PedalCMS/wp-cmf/releases)
+2. Verify the release notes are correct
+3. Download and test the distribution packages
+
+## Quick Release Commands
+
+```bash
+# Run all checks
+composer ci
+
+# Create release
+VERSION="1.0.0"
+git add CHANGELOG.md README.md
+git commit -m "Prepare release v$VERSION"
+git push origin main
+git tag -a "v$VERSION" -m "Release v$VERSION"
+git push origin "v$VERSION"
+```
+
+## Hotfix Process
+
+For urgent bug fixes to a released version:
+
+```bash
+# Create hotfix branch from tag
+git checkout -b hotfix/1.0.1 v1.0.0
+
+# Make fixes, update CHANGELOG.md
+git add .
+git commit -m "Fix critical bug X"
+
+# Merge to main
+git checkout main
+git merge hotfix/1.0.1
+git push origin main
+
+# Tag the release
+git tag -a v1.0.1 -m "Release v1.0.1"
+git push origin v1.0.1
+
+# Clean up
+git branch -d hotfix/1.0.1
+```
+
+## Troubleshooting
+
+### Release workflow failed
+
+1. Check the [Actions tab](https://github.com/PedalCMS/wp-cmf/actions) for error details
+2. Common issues:
+   - Invalid version format (must be `vX.Y.Z`)
+   - Missing CHANGELOG.md section for the version
+   - Tests or checks failing
+
+### Need to delete a release
+
+```bash
+# Delete the tag locally and remotely
+git tag -d v1.0.0
+git push origin :refs/tags/v1.0.0
+```
+
+Then delete the release from the GitHub UI.


### PR DESCRIPTION
Introduce a GitHub Actions workflow for automated releases, including packaging and release notes extraction. Add .distignore for distribution exclusions, a changelog following Keep a Changelog, and detailed release process documentation.